### PR TITLE
fix: handle symlinks when comparing to __filename

### DIFF
--- a/run.js
+++ b/run.js
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 
+const { existsSync, realpathSync } = require('fs');
 const { homedir } = require('os');
-const path = require('path');
+const { resolve }= require('path');
 
-const ePath = path.resolve(homedir(), '.electron_build_tools', 'src', 'e');
-process.argv = process.argv.map(arg => arg === __filename ? ePath : arg);
+const ePath = resolve(homedir(), '.electron_build_tools', 'src', 'e');
+process.argv = process.argv.map(arg => {
+  if (existsSync(arg)) {
+    return realpathSync(arg) === realpathSync(__filename) ? ePath : arg;
+  }
+  return arg;
+});
 
 require(ePath);


### PR DESCRIPTION
Fixes an issue where paths wouldn't resolve correctly on Linux with symlinks.

cc @MarshallOfSound 