### PR TITLE
feat: add long-form name for command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A wrapper toolkit for working with Electron.js source code",
   "main": "index.js",
   "bin": {
-    "e": "./run.js"
+    "e": "./run.js",
+    "electron-build-tools": "./run.js"
   },
   "scripts": {
     "preinstall": "node preinstall.js",


### PR DESCRIPTION
Some discussion on Slack led to this PR. Providing a long-form name makes it a little bit safer to programmatically run `build-tools` commands without the risk of accidentally invoking something else due to the short ambiguous `e` name. Code can use the long-form and be sure it's getting what it expects.