### PR TITLE
fix: errors don't fail silently

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -55,6 +55,9 @@ function install() {
     if (existsSync(installPath)) {
       rmdirSync(installPath, { recursive: true });
     }
+
+    // Set the exit code to an error so npm will also show the error instead of failing silently.
+    process.exitCode = 1;
   }
 }
 


### PR DESCRIPTION
When working in fresh environments I forget to install yarn before installing build-tools. When the `yarn install` command fails, this installer script fails silently and I am left with no clues for why build-tools secretly failed to install.

This PR makes the install script exit with a non-zero exit code so npm will tell you why it failed.