### PR TITLE
fix: checkout main branch for build-tools

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -23,12 +23,12 @@ function install() {
         spawnSync('git', ['fetch'], { stdio: 'inherit', cwd: installPath }),
       );
       throwForBadSpawn(
-        'git checkout master',
-        spawnSync('git', ['checkout', 'master', '-f'], { stdio: 'inherit', cwd: installPath }),
+        'git checkout main',
+        spawnSync('git', ['checkout', 'main', '-f'], { stdio: 'inherit', cwd: installPath }),
       );
       throwForBadSpawn(
         'git reset',
-        spawnSync('git', ['reset', '--hard', 'origin/master'], {
+        spawnSync('git', ['reset', '--hard', 'origin/main'], {
           stdio: 'inherit',
           cwd: installPath,
         }),


### PR DESCRIPTION
This got missed when https://github.com/electron/build-tools/issues/332 was implemented. The installer is continuing to checkout `master` instead of `main`, which is a not good experience for new installs.

@codebytere @ckerr 