### PR TITLE
fix: use e --help when testing usability of e

### DIFF
--- a/test/module.test.js
+++ b/test/module.test.js
@@ -16,6 +16,6 @@ it('adds e to the user PATH', () => {
 });
 
 it('can execute e', () => {
-  const info = execSync('e');
+  const info = execSync('e --help');
   assert.match(info.toString(), /Electron build tool/);
 });


### PR DESCRIPTION
I believe this is needed as a result of https://github.com/electron/build-tools/pull/336. Looks like now a bare `e` invocation will have an exit code of 1, which does seem to be more standard behavior (same as `git`, `open`, and other bare commands that show help). However that means `execSync` chokes on it since it's coming back as an error, so switch to using `e --help` instead in this test.