### PR TITLE
ci: fix and improve lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+    - name: Setup Node.js
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
       with:
-        node-version: 16.x
+        node-version: lts/*
     - name: Lint
       run: |
-        npm ci
-        npm run lint
+        yarn install --frozen-lockfile
+        yarn run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macOS-latest


### PR DESCRIPTION
Lint workflow was broken by a9bb65d258517920915c3b42c0a3599ac606b640.

Also:
* Set permissions
* Pin action SHAs
* Use current Node.js LTS instead of a specific version