### PR TITLE
chore: fix lint on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "preinstall": "node preinstall.js",
-    "lint": "prettier --check '**/*.js'",
-    "prettier:write": "prettier --write '**/*.js'",
+    "lint": "prettier --check \"**/*.js\"",
+    "prettier:write": "prettier --write \"**/*.js\"",
     "test": "npx mocha --reporter spec"
   },
   "repository": {


### PR DESCRIPTION
#22 should have used double quotes to play nice with Windows, so fixing that.