### PR TITLE
ci: drop Node.js v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ workflows:
                 - '20.8'
                 - '18.18'
                 - '16.20'
-                - '14.21'
       - cfa/release:
           requires:
             - test


### PR DESCRIPTION
Unblocks https://github.com/electron/build-tools-installer/pull/24

CircleCI has switched executors from MacOS / [Medium Gen2](https://circleci.com/docs/2.0/configuration-reference/#resourceclass) to MacOS / [M1 Medium](https://circleci.com/docs/2.0/configuration-reference/#resourceclass) - Node.js v14 does not release an arm64 version and therefore does not work anymore.