### PR TITLE
chore: add `engines.node` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "preinstall.js",
     "run.js"
   ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "scripts": {
     "preinstall": "node preinstall.js",
     "lint": "prettier --check \"**/*.js\"",


### PR DESCRIPTION
This is the minimum LTS version where `yarn test` works.