### PR TITLE
ci: drop Node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ workflows:
               node-version:
                 - '20.8'
                 - '18.18'
-                - '16.20'
       - cfa/release:
           requires:
             - test


### PR DESCRIPTION
`electron/build-tools` now requires Node 18, so the tests here are falling over when it tries to bootstrap.