### PR TITLE
fix: don't spawn `shell: true` on Windows anymore

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -62,7 +62,6 @@ function install() {
       spawnSync(process.execPath, [yarnPath, 'install'], {
         stdio: 'inherit',
         cwd: installPath,
-        shell: isWin,
       }),
     );
   } catch (err) {


### PR DESCRIPTION
Refs https://github.com/electron/build-tools-installer/pull/51

Fixes:

```
npm error HEAD is now at 4430e4a build(deps): bump actions/setup-node from 6.0.0 to 6.1.0 (#786)
npm error 'C:\Program' is not recognized as an internal or external command,
npm error operable program or batch file.
npm error Failed to install build-tools:  Error: Command "yarn install" failed with exit code 1
npm error     at throwForBadSpawn (file:///C:/Users/ContainerAdministrator/AppData/Roaming/npm/node_modules/@electron/build-tools/preinstall.js:13:11)
npm error     at install (file:///C:/Users/ContainerAdministrator/AppData/Roaming/npm/node_modules/@electron/build-tools/preinstall.js:60:5)
npm error     at file:///C:/Users/ContainerAdministrator/AppData/Roaming/npm/node_modules/@electron/build-tools/preinstall.js:81:1
npm error     at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
npm error     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
npm error     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
npm error A complete log of this run can be found in: C:\Users\ContainerAdministrator\AppData\Local\npm-cache\_logs\2026-01-12T14_20_07_275Z-debug-0.log
```

as seen in https://github.com/electron/electron/actions/runs/20922534306/job/60111797235?pr=49362