### PR TITLE
ci: bump Node.js version to fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '22.12.x'
+          - '22.x'
         os:
           - macos-latest
           - ubuntu-latest


### PR DESCRIPTION
CI has been busted since recent refactorings of `build-tools`.